### PR TITLE
fix indentation after {:else} in specific cases

### DIFF
--- a/svelte-mode.el
+++ b/svelte-mode.el
@@ -472,7 +472,8 @@ This is used by `svelte--pre-command'.")
 
 (defun svelte--html-block-offset ()
   "Indentation offset of Svelte blocks like {#if...}, {#each...}."
-  (cond ((or (svelte--previous-block "beginning"))
+  (cond ((or (svelte--previous-block "beginning")
+	     (svelte--previous-block "middle"))
          svelte-basic-offset)
         ((or (svelte--current-block "middle")
              (svelte--current-block "end")


### PR DESCRIPTION
Hi! I found a couple situations when indentation after {:else} block don't work.
- when markup between {#if ...} and {:else} consists only of text. Example:
```
{#if foo}
  some text
{:else}
different text indented at the same level as else block (same result with markup in else branch)
{/if}
```
- when {#each ...} has `<li>` as a direct child. Example:
```
<ul>
  {#each items as item (item.id)}
    <li>{item.title}</li>
  {:else}
  <li>indented at the same level as else block</li>
{/each}
</ul>
```

I debug it for a bit and figured out that the incorrect indentation calculated by `sgml-calculate-indent` [here](https://github.com/leafOfTree/svelte-mode/blob/266db1fc882efe17bba7033d69ec663ab4cca5f9/svelte-mode.el#L462). A possible solution is to modify `svelte--html-block-offset` so it will return `svelte-basic-offset` also when `(svelte--previous-block "middle")`.